### PR TITLE
disable updatenotification app

### DIFF
--- a/v20.04/overlay/etc/owncloud.d/40-qnap-config.sh
+++ b/v20.04/overlay/etc/owncloud.d/40-qnap-config.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 echo "Setting qnap specific settings..."
 occ config:system:set updatechecker --type boolean --value=false
+occ app:disable updatenotification
 occ config:app:set --value true core umgmt_show_is_enabled
 occ config:app:set --value true core umgmt_show_last_login
 occ config:system:set grace_period.demo_key.show_popup --type=boolean --value=false


### PR DESCRIPTION
On QNAP we don't want to offer any ownCloud Core updates through any mechanisms except the QNAP Store.
